### PR TITLE
Use 'and' in query only for >1 clauses.

### DIFF
--- a/lib/cloudsearchable/query_chain.rb
+++ b/lib/cloudsearchable/query_chain.rb
@@ -204,7 +204,7 @@ module Cloudsearchable
     def to_q
       raise NoClausesError, "no search terms were specified" if (@clauses.nil? || @clauses.empty?) && (@q.nil? || @q.empty?)
       
-      bq = (@clauses.count > 0) ? "(and #{@clauses.join(' ')})" : @clauses.first
+      bq = (@clauses.count > 1) ? "(and #{@clauses.join(' ')})" : @clauses.first
       {
         q: @q,
         bq: bq,


### PR DESCRIPTION
This addresses issue #2.
