### PR TITLE
Adding active support instrumentation

### DIFF
--- a/lib/cloudsearchable.rb
+++ b/lib/cloudsearchable.rb
@@ -8,6 +8,7 @@ require 'cloudsearchable/config'
 
 require 'active_support/inflector'
 require 'active_support/core_ext/string'
+require 'active_support/notifications'
 
 module Cloudsearchable
   def self.configure


### PR DESCRIPTION
The code change adds Active support instrumentations to AWS cloudsearch calls.

Cloudsearchable clients can subscribe to these instrumented calls using active support notification subscriber. For example to subscribe to search calls, client application should create a subscriber like this:

ActiveSupport::Notifications.subscribe('cloudsearchable.execute_query') do |*args|
  #.. do something here with args
end
