### PR TITLE
Replace dependency on aws-sdk with aws-sdk-v1

### DIFF
--- a/cloudsearchable.gemspec
+++ b/cloudsearchable.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "yard"
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-v1'
 
   # testing dependencies
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The gemspec did not list a major version dependency. Users updating gems will be pulling in the v2 SDK which is not backwards compatible. To allow downstream users to use both this gem and v2 of 'aws-sdk', the dependency on v1 needs to be changed.

The v1 'aws-sdk' gem is an empty shell that simply loads 'aws-sdk-v1', so this should be fully backwards compatible.