### PR TITLE
Specs pass

### DIFF
--- a/cloudsearchable.gemspec
+++ b/cloudsearchable.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-v1'
 
   # testing dependencies
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", '~> 2'
   spec.add_development_dependency "activemodel"
 end

--- a/lib/cloudsearchable/cloud_search.rb
+++ b/lib/cloudsearchable/cloud_search.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'json'
 
 module CloudSearch


### PR DESCRIPTION
1) Correctly require AWS SDK. The gem is currently unusable with this combination of gemspec and 'require' statement.
2) Specify rspec major version 2. rspec 3 causes some existing tests to fail.