### PR TITLE
updated aws sdk version for ruby3

### DIFF
--- a/cloudsearchable.gemspec
+++ b/cloudsearchable.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "yard"
-  spec.add_dependency 'aws-sdk', "~> 2"
+  spec.add_dependency 'aws-sdk', "~> 3"
 
   # testing dependencies
   spec.add_development_dependency "rspec", '~> 3'

--- a/lib/cloudsearchable/version.rb
+++ b/lib/cloudsearchable/version.rb
@@ -1,3 +1,3 @@
 module Cloudsearchable
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
*Issue #, if available:*
AWS sdk 2 is no longer supported and doesn't support ruby 3 

*Description of changes:*
Just bumped the version to the new version of the SDK and checked that all the tests passed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Edit: CI failed for bundler being out of date and other ruby setup issues although some builds against old versions still passed
